### PR TITLE
Enhance raw_to_fits tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,24 +39,26 @@ python structure_analysis.py path/to/calibration [--reduce]
 
 ## Raw to FITS Conversion
 
-The `utils` package provides a helper to convert `.raw` camera frames into FITS
-files.  Each acquisition section should contain:
+The `utils.raw_to_fits` module converts the raw camera frames of the calibration
+datasets into FITS format. It expects the paths to the three dataset roots:
+`TestSection1` (bias), `TestSection2` (dark) and `TestSection3` (flat).
 
-- `configFile.txt` – configuration parameters (e.g. `HEIGHT`, `WIDTH`,
-  `BIT_DEPTH`).
-- `temperatureLog.csv` – CSV with two columns: frame index and sensor
-  temperature.
-- A folder with the `.raw` frames (defaults to `frames/`).
+In the bias and dark sections the tool scans directories named `T<temp>` and,
+inside each of them, every `attempt<n>` folder. Each attempt must contain
+`configFile.txt`, `temperatureLog.csv` and a `frames/` directory with the raw
+files.  The flat section may include an extra level (e.g. `20frames/`) before the
+`T<temp>` folders, which are processed in the same way.
 
-To convert one or more sections run:
+Run the conversion with:
 
 ```bash
-python -m utils.raw_to_fits <TestSection1> <TestSection2> <TestSection3>
+python -m utils.raw_to_fits path/to/TestSection1 path/to/TestSection2 path/to/TestSection3
 ```
 
-A `fits/` subdirectory will be created inside each section containing the
-resulting FITS files with the configuration values and the corresponding frame
-temperature written into the header.
+For each attempt a `fits/` directory is created alongside `frames/` containing
+the generated FITS files with the configuration values and per-frame
+temperature written to the header.
 
 For more options refer to the READMEs within each submodule.
+
 

--- a/utils/raw_to_fits.py
+++ b/utils/raw_to_fits.py
@@ -4,50 +4,93 @@
 import os
 import csv
 import glob
-from typing import Dict, Iterable, Optional
+import re
+from typing import Dict, Iterable, Optional, List
+
+DEFAULT_HEIGHT = 2048
+DEFAULT_WIDTH = 2048
+DEFAULT_BIT_DEPTH = 16
 
 import numpy as np
 from astropy.io import fits
 
 
 def read_config(path: str) -> Dict[str, str]:
-    """Parse a simple key=value configuration file."""
+    """Parse a configuration file using ``key=value`` or ``key: value`` syntax."""
+
     cfg: Dict[str, str] = {}
-    with open(path, "r") as f:
+    if not os.path.isfile(path):
+        return cfg
+
+    with open(path, "r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
             if "=" in line:
                 k, v = line.split("=", 1)
-                cfg[k.strip()] = v.strip()
+            elif ":" in line:
+                k, v = line.split(":", 1)
+            else:
+                continue
+            cfg[k.strip()] = v.strip()
+
     return cfg
 
 
 def read_temperature_log(path: str) -> Dict[int, float]:
-    """Read a temperatureLog.csv with frame index and temperature."""
+    """Read ``temperatureLog.csv`` and return a mapping ``frame -> temperature``."""
+
     temps: Dict[int, float] = {}
+    if not os.path.isfile(path):
+        return temps
+
     with open(path, newline="") as csvfile:
-        reader = csv.reader(csvfile)
-        for row in reader:
-            if not row or len(row) < 2:
-                continue
-            try:
-                frame = int(row[0])
-                temp = float(row[1])
-            except ValueError:
-                # skip header or malformed rows
-                continue
-            temps[frame] = temp
+        # Try to autodetect delimiter and field names
+        sample = csvfile.read(1024)
+        csvfile.seek(0)
+        try:
+            dialect = csv.Sniffer().sniff(sample)
+        except csv.Error:
+            dialect = csv.excel
+
+        csvfile.seek(0)
+        reader = csv.DictReader(csvfile, dialect=dialect)
+
+        if "Temperature" in reader.fieldnames:
+            for row in reader:
+                try:
+                    frame = int(row.get("FrameNum", row.get("frame", row[reader.fieldnames[0]])))
+                    temp = float(row["Temperature"])
+                except (ValueError, KeyError):
+                    continue
+                temps[frame] = temp
+        else:
+            # Fallback: use raw reader and assume temperature is the 7th column
+            csvfile.seek(0)
+            simple_reader = csv.reader(csvfile, delimiter=dialect.delimiter)
+            for row in simple_reader:
+                if not row or len(row) < 7:
+                    continue
+                try:
+                    frame = int(row[0])
+                    temp = float(row[6])
+                except ValueError:
+                    continue
+                temps[frame] = temp
+
     return temps
 
 
 def _parse_dimensions(cfg: Dict[str, str]) -> tuple[int, int, int]:
-    height = int(cfg.get("HEIGHT", cfg.get("height", 0)))
-    width = int(cfg.get("WIDTH", cfg.get("width", 0)))
-    bit_depth = int(cfg.get("BIT_DEPTH", cfg.get("bit_depth", 16)))
-    if not height or not width:
-        raise ValueError("Image dimensions missing in config file")
+    """Return image ``height``, ``width`` and ``bit_depth`` from config.
+
+    Values fall back to defaults if not present.
+    """
+
+    height = int(cfg.get("HEIGHT", cfg.get("height", DEFAULT_HEIGHT)))
+    width = int(cfg.get("WIDTH", cfg.get("width", DEFAULT_WIDTH)))
+    bit_depth = int(cfg.get("BIT_DEPTH", cfg.get("bit_depth", DEFAULT_BIT_DEPTH)))
     return height, width, bit_depth
 
 
@@ -57,30 +100,40 @@ def _open_raw(path: str, height: int, width: int, dtype: np.dtype) -> np.ndarray
     return data.reshape((height, width))
 
 
-def convert_section(section_path: str, raw_subdir: str = "frames") -> list[str]:
-    """Convert all .raw files inside ``section_path`` to FITS files.
+def convert_attempt(attempt_path: str, calibration: str, raw_subdir: str = "frames") -> List[str]:
+    """Convert all ``.raw`` files inside an attempt directory into FITS files.
+
+    The resulting FITS files are stored in a ``fits/`` subdirectory within the
+    attempt. Basic configuration values and per-frame temperature information are
+    written to the FITS header.
 
     Parameters
     ----------
-    section_path: str
-        Path to a section directory containing ``configFile.txt`` and
+    attempt_path: str
+        Path to the attempt directory containing ``configFile.txt`` and
         ``temperatureLog.csv``.
+    calibration: str
+        Calibration type (``BIAS``, ``DARK`` or ``FLAT``) stored in the header.
     raw_subdir: str, optional
         Name of the sub-directory containing ``.raw`` files. If the directory
-        does not exist, ``section_path`` is searched directly.
+        does not exist, ``attempt_path`` is searched directly.
 
     Returns
     -------
     list[str]
         Paths to the generated FITS files.
     """
-    config_path = os.path.join(section_path, "configFile.txt")
-    temp_log_path = os.path.join(section_path, "temperatureLog.csv")
-    raw_dir = os.path.join(section_path, raw_subdir)
-    if not os.path.isdir(raw_dir):
-        raw_dir = section_path
+    config_path = os.path.join(attempt_path, "configFile.txt")
+    if not os.path.isfile(config_path):
+        config_path = os.path.join(attempt_path, "config.txt")
 
-    out_dir = os.path.join(section_path, "fits")
+    temp_log_path = os.path.join(attempt_path, "temperatureLog.csv")
+
+    raw_dir = os.path.join(attempt_path, raw_subdir)
+    if not os.path.isdir(raw_dir):
+        raw_dir = attempt_path
+
+    out_dir = os.path.join(attempt_path, "fits")
     os.makedirs(out_dir, exist_ok=True)
 
     cfg = read_config(config_path)
@@ -94,8 +147,9 @@ def convert_section(section_path: str, raw_subdir: str = "frames") -> list[str]:
     for idx, raw_file in enumerate(raw_files):
         data = _open_raw(raw_file, height, width, dtype)
         header = fits.Header()
+        header["CALTYPE"] = calibration
         for k, v in cfg.items():
-            header[k.upper()] = v
+            header[k.upper()[:8]] = v
         if idx in temps:
             header["CCD_TEMP"] = temps[idx]
         hdul = fits.HDUList([fits.PrimaryHDU(data, header=header)])
@@ -106,26 +160,71 @@ def convert_section(section_path: str, raw_subdir: str = "frames") -> list[str]:
     return fits_paths
 
 
-def convert_many(sections: Iterable[str]) -> None:
-    for sec in sections:
-        print(f"Converting section {sec} ...")
-        convert_section(sec)
+def _find_attempts_in_temperature_dir(t_dir: str) -> List[str]:
+    attempts: List[str] = []
+    for entry in os.scandir(t_dir):
+        if entry.is_dir() and entry.name.lower().startswith("attempt"):
+            attempts.append(entry.path)
+    return attempts
+
+
+def gather_attempts(root: str, nested: bool = False) -> List[str]:
+    """Collect attempt directories in ``root``.
+
+    If ``nested`` is ``True`` (used for FLAT datasets), one level of subfolder is
+    searched before looking for ``T<temp>`` directories.
+    """
+
+    attempt_dirs: List[str] = []
+
+    def process_parent(parent: str):
+        for entry in os.scandir(parent):
+            if entry.is_dir() and re.match(r"^T-?\d+", entry.name):
+                attempt_dirs.extend(_find_attempts_in_temperature_dir(entry.path))
+
+    if nested:
+        for sub in os.scandir(root):
+            if sub.is_dir() and re.match(r"^T-?\d+", sub.name):
+                process_parent(sub.path)
+            elif sub.is_dir():
+                for tdir in os.scandir(sub.path):
+                    if tdir.is_dir() and re.match(r"^T-?\d+", tdir.name):
+                        attempt_dirs.extend(_find_attempts_in_temperature_dir(tdir.path))
+    else:
+        process_parent(root)
+
+    return attempt_dirs
+
+
+def convert_many(bias_root: str, dark_root: str, flat_root: str) -> None:
+    datasets = [
+        (bias_root, "BIAS", False),
+        (dark_root, "DARK", False),
+        (flat_root, "FLAT", True),
+    ]
+
+    for root, caltype, nested in datasets:
+        print(f"Processing {caltype} dataset at {root}...")
+        for attempt in gather_attempts(root, nested=nested):
+            print(f"  Converting attempt {attempt} ...")
+            convert_attempt(attempt, calibration=caltype)
 
 
 def main(argv: Optional[Iterable[str]] = None) -> None:
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Convert raw frames to FITS format using configuration files",
+        description=(
+            "Convert raw frames from bias, dark and flat datasets to FITS."
+        )
     )
-    parser.add_argument(
-        "sections",
-        nargs="+",
-        metavar="SECTION",
-        help="Path(s) to acquisition sections",
-    )
+    parser.add_argument("bias_section", help="Path to TestSection1 (BIAS)")
+    parser.add_argument("dark_section", help="Path to TestSection2 (DARK)")
+    parser.add_argument("flat_section", help="Path to TestSection3 (FLAT)")
+
     args = parser.parse_args(argv)
-    convert_many(args.sections)
+
+    convert_many(args.bias_section, args.dark_section, args.flat_section)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- improve `utils.raw_to_fits` to crawl bias/dark/flat dataset folders
- allow config files with `:` or `=` delimiters
- support complex `temperatureLog.csv` formats
- document the new behaviour in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68480cef33008331b250340496b82293