### PR TITLE
Improve error handling in conversion and optional ObservationManager

### DIFF
--- a/dark_pipeline/dark_pipeline/steps/outgasing_destruction_analysis.py
+++ b/dark_pipeline/dark_pipeline/steps/outgasing_destruction_analysis.py
@@ -30,10 +30,12 @@ from collections import defaultdict
 
 # Adjust as needed for your environment
 try:
-    from observation_manager.observation_manager import ObservationManager
-except ImportError:
-    print("Could not import ObservationManager. Ensure it's installed or on PYTHONPATH.")
-    sys.exit(1)
+    from .observation_manager.observation_manager import ObservationManager
+except Exception:  # ImportError or other issues
+    ObservationManager = None
+    print(
+        "Could not import ObservationManager. Some features will be disabled."
+    )
 
 
 ##############################################################################

--- a/utils/raw_to_fits.py
+++ b/utils/raw_to_fits.py
@@ -296,7 +296,15 @@ def convert_many(bias_root: str, dark_root: str, flat_root: str) -> None:
 
     for root, caltype, depth in datasets:
         print(f"Processing {caltype} dataset at {root}...")
-        for attempt in gather_attempts(root, max_depth=depth):
+        if not os.path.isdir(root):
+            print(f"  WARNING: path {root} does not exist or is not a directory")
+            continue
+
+        attempts = gather_attempts(root, max_depth=depth)
+        if not attempts:
+            print(f"  WARNING: no attempts found in {root}")
+
+        for attempt in attempts:
             print(f"  Converting attempt {attempt} ...")
             convert_attempt(attempt, calibration=caltype, index_rows=index_rows)
 


### PR DESCRIPTION
## Summary
- warn when dataset roots don't exist or contain no attempts in `raw_to_fits`
- make ObservationManager optional so analysis functions can be imported without it

## Testing
- `pip install numpy astropy pytest matplotlib tqdm`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684834f47c488331a3d97071e0f9e55c