### PR TITLE
Update FITS metadata mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ python -m utils.raw_to_fits path/to/TestSection1 path/to/TestSection2 path/to/Te
 For each attempt a `fits/` directory is created alongside `frames/` containing
 the generated FITS files. All columns present in `temperatureLog.csv` are
 written into the FITS header using short keywords (for instance
-`FrameNum` → `FRAMENUM`, `ExpTime` → `EXPTIME`).  Exposure time values are
+`FrameNum` → `FRAMENUM`, `ExpTime` → `EXPTIME`).  Certain columns are mapped
+to more concise names: `ExpGain` → `GAIN`, `Temperature` → `TEMP`,
+`InitialTemp` → `TEMP_0` and `ExtTemperature` → `EQTEMP`. Exposure time values are
 converted from microseconds to seconds.  If the raw filename encodes the
 exposure time (e.g. `exp0.1s` or `exp_1.2e-05s`) it is only used when the CSV
 does not provide one. Any temperature indicated in the filename is stored under

--- a/tests/test_raw_to_fits.py
+++ b/tests/test_raw_to_fits.py
@@ -33,3 +33,28 @@ def test_convert_attempt_parses_exptime(tmp_path):
     assert hdr["EXPTIME"] == 12 / 1e6
     assert hdr["TEMP"] == -0.5
     assert hdr["FILETEMP"] == 0
+
+
+def test_convert_attempt_custom_headers(tmp_path):
+    attempt = tmp_path / "attempt0"
+    frames = attempt / "frames"
+    frames.mkdir(parents=True)
+
+    with open(attempt / "configFile.txt", "w") as f:
+        f.write("WIDTH: 2\nHEIGHT: 2\nBIT_DEPTH: 16\n")
+
+    with open(attempt / "temperatureLog.csv", "w") as f:
+        f.write(
+            "FrameNum,TimeStamp,ExtTemperature,ExpTime,RealExpTime,ExpGain,Temperature,InitialTemp\n"
+        )
+        f.write("0,100,5,12,12,2,-10,-11\n")
+
+    arr0 = np.arange(4, dtype=np.uint16).reshape(2, 2)
+    arr0.tofile(frames / "f0.raw")
+
+    fits_file = convert_attempt(str(attempt), "BIAS")[0]
+    hdr = fits.getheader(fits_file)
+    assert hdr["GAIN"] == 2
+    assert hdr["TEMP"] == -10
+    assert hdr["TEMP_0"] == -11
+    assert hdr["EQTEMP"] == 5

--- a/utils/raw_to_fits.py
+++ b/utils/raw_to_fits.py
@@ -83,12 +83,13 @@ def adapt_metadata_keys(row_metadata: Dict[str, str]) -> Dict[str, object]:
     mapping = {
         "FrameNum": "FRAMENUM",
         "TimeStamp": "TIMESTAMP",
-        "ExtTemperature": "EXTTEMP",
+        "ExtTemperature": "EQTEMP",
         "ExpTime": "EXPTIME",
         "RealExpTime": "REXPTIME",
-        "ExpGain": "EXPGAIN",
+        "ExpGain": "GAIN",
         "Temperature": "TEMP",
-        "InitialTemp": "INITTMP",
+        "InitialTemp": "TEMP_0",
+        "initialTemp": "TEMP_0",
         "DeltaTemperature": "DELTMP",
         "PowerCons": "POWCONS",
         # additional common names for the detector temperature
@@ -268,8 +269,10 @@ def convert_attempt(
                 "EXPTIME",
                 "REXPTIME",
                 "TEMP",
+                "TEMP_0",
+                "GAIN",
                 "FILETEMP",
-                "EXTTEMP",
+                "EQTEMP",
             ):
                 if key in header:
                     row[key] = header[key]


### PR DESCRIPTION
## Summary
- map ExpGain, Temperature, InitialTemp and ExtTemperature to GAIN, TEMP, TEMP_0 and EQTEMP
- record these fields in the `fits_index.csv`
- note the new keyword mapping in the README
- test the custom header names

## Testing
- `pip install numpy astropy pytest matplotlib tqdm --quiet`
- `PYTHONPATH=. pytest -q` *(fails: observation_manager missing)*

------
https://chatgpt.com/codex/tasks/task_e_68483cac1d2c8331845f987feac2aa9f