### PR TITLE
Add missing pytest dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ numpy
 astropy
 matplotlib
 tqdm
+pytest
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,12 +1,13 @@
 # Testing Dataset Analysis Utilities
 
-The unit tests use `pytest` and require `numpy` and `astropy`.
+The unit tests require `numpy`, `astropy`, and `pytest`.
 
 ## Running the tests
 
-1. Install the dependencies (if not already available):
+1. Install the dependencies (if not already available). They are listed in
+   `requirements.txt` and can be installed with:
    ```bash
-   pip install numpy astropy pytest
+   pip install -r requirements.txt
    ```
 
 2. Execute the test suite from the repository root:


### PR DESCRIPTION
## Summary
- list `pytest` in `requirements.txt`
- document installing dependencies via `requirements.txt` in test README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483fecb8f4833191f6c8978c0ff879