### PR TITLE
Update README with verbose flag usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Run the conversion with:
 python -m utils.raw_to_fits path/to/TestSection1 path/to/TestSection2 path/to/TestSection3
 ```
 
+Add the `--verbose` option to print warnings about missing metadata, e.g.
+
+```bash
+python -m utils.raw_to_fits path/to/TestSection1 path/to/TestSection2 path/to/TestSection3 --verbose
+```
+
 For each attempt a `fits/` directory is created alongside `frames/` containing
 the generated FITS files. All columns present in `temperatureLog.csv` are
 written into the FITS header using short keywords (for instance


### PR DESCRIPTION
## Summary
- document the `--verbose` option in the Raw to FITS conversion instructions

## Testing
- `pip install numpy astropy pytest matplotlib tqdm`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483fe9504c833195d83e39a18f36c0