### PR TITLE
Support deeper attempt search

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ datasets into FITS format. It expects the paths to the three dataset roots:
 In the bias section the tool scans directories named `T<temp>` and, inside each
 of them, every `attempt<n>` folder.  Dark and flat datasets may include several
 intermediate folders (e.g. `20Frames/<exptime>s/` or
-`ContinuousFrames/T<temp>/<exptime>s`) before reaching the attempts.  Any
-combination up to two extra levels is supported.  Each attempt must contain
+`ContinuousFrames/T<temp>/<exptime>s`) before reaching the attempts.  The
+converter now searches up to six directory levels by default so deeper
+structures are handled automatically.  Each attempt must contain
 `configFile.txt`, `temperatureLog.csv` and a `frames/` directory with the raw
 files.  All such structures are handled automatically.
 
@@ -69,10 +70,11 @@ Run the conversion with:
 python -m utils.raw_to_fits path/to/TestSection1 path/to/TestSection2 path/to/TestSection3
 ```
 
-Add the `--verbose` option to print warnings about missing metadata, e.g.
+Add the `--verbose` option to print warnings about missing metadata.  The search
+depth for dark and flat attempts can be changed with `--search-depth`, e.g.
 
 ```bash
-python -m utils.raw_to_fits path/to/TestSection1 path/to/TestSection2 path/to/TestSection3 --verbose
+python -m utils.raw_to_fits path/to/TestSection1 path/to/TestSection2 path/to/TestSection3 --verbose --search-depth 6
 ```
 
 For each attempt a `fits/` directory is created alongside `frames/` containing

--- a/tests/test_gather_attempts.py
+++ b/tests/test_gather_attempts.py
@@ -9,3 +9,16 @@ def test_gather_attempts_handles_nested_dark(tmp_path):
     attempts = set(map(pathlib.Path, gather_attempts(str(root), max_depth=4)))
     assert (root / "20Frames" / "T0" / "0.5s" / "attempt0") in attempts
     assert (root / "ContinuousFrames" / "0.2s" / "T5" / "attempt1") in attempts
+
+
+def test_gather_attempts_deep_hierarchy(tmp_path):
+    root = tmp_path / "TestSection2"
+    (root / "20Frames" / "T20" / "T0" / "0.5s" / "attempt0" / "frames").mkdir(
+        parents=True
+    )
+
+    attempts = set(map(pathlib.Path, gather_attempts(str(root), max_depth=6)))
+    assert (
+        root / "20Frames" / "T20" / "T0" / "0.5s" / "attempt0"
+    ) in attempts
+

--- a/utils/raw_to_fits.py
+++ b/utils/raw_to_fits.py
@@ -307,15 +307,23 @@ def gather_attempts(root: str, max_depth: int = 2) -> List[str]:
     return attempt_dirs
 
 
-def convert_many(bias_root: str, dark_root: str, flat_root: str) -> None:
+def convert_many(
+    bias_root: str,
+    dark_root: str,
+    flat_root: str,
+    search_depth: int = 6,
+) -> None:
+    """Convert all attempts contained in the three dataset sections."""
+
     index_rows: List[Dict[str, object]] = []
 
     datasets = [
         # search depth 2 should be enough for bias (T<temp>/attempt<n>)
         (bias_root, "BIAS", 2),
         # dark and flat datasets may include additional folders like exposure time
-        (dark_root, "DARK", 4),
-        (flat_root, "FLAT", 4),
+        # or temperature groups; use a larger depth by default
+        (dark_root, "DARK", search_depth),
+        (flat_root, "FLAT", search_depth),
     ]
 
     for root, caltype, depth in datasets:
@@ -360,6 +368,14 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
         action="store_true",
         help="Enable detailed logging messages",
     )
+    parser.add_argument(
+        "--search-depth",
+        type=int,
+        default=6,
+        help=(
+            "Maximum directory depth when searching for dark and flat attempts"
+        ),
+    )
 
     args = parser.parse_args(argv)
 
@@ -368,7 +384,12 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
         format="%(levelname)s: %(message)s",
     )
 
-    convert_many(args.bias_section, args.dark_section, args.flat_section)
+    convert_many(
+        args.bias_section,
+        args.dark_section,
+        args.flat_section,
+        search_depth=args.search_depth,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support user-defined attempt search depth when converting raw files
- test `gather_attempts` with deeper directories
- document new search depth and CLI option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684846ea1ad88331855e97b3f530403c