### PR TITLE
Improve warning for missing attempts

### DIFF
--- a/utils/raw_to_fits.py
+++ b/utils/raw_to_fits.py
@@ -339,7 +339,10 @@ def convert_many(
 
         attempts = gather_attempts(root, max_depth=depth)
         if not attempts:
-            print(f"  WARNING: no attempts found in {root}")
+            print(
+                f"  WARNING: no attempts found in {root} "
+                f"(try --search-depth {depth + 2} or more)"
+            )
 
         for attempt in attempts:
             print(f"  Converting attempt {attempt} ...")


### PR DESCRIPTION
## Summary
- refine warning message in `convert_many` when no attempts are found

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484be58510833192a829dcaf95cbce