### PR TITLE
Improve warning for missing attempts

### DIFF
--- a/tests/test_gather_attempts.py
+++ b/tests/test_gather_attempts.py
@@ -22,3 +22,15 @@ def test_gather_attempts_deep_hierarchy(tmp_path):
         root / "20Frames" / "T20" / "T0" / "0.5s" / "attempt0"
     ) in attempts
 
+
+def test_gather_attempts_frames_without_attempt_dir(tmp_path):
+    root = tmp_path / "TestSection2"
+    attempt = root / "20Frames" / "T20" / "T0" / "0.4s"
+    frames = attempt / "frames"
+    frames.mkdir(parents=True)
+    (attempt / "configFile.txt").write_text("WIDTH: 1\nHEIGHT: 1\nBIT_DEPTH: 16\n")
+    (attempt / "temperatureLog.csv").write_text("FrameNum\n0\n")
+
+    attempts = set(map(pathlib.Path, gather_attempts(str(root), max_depth=6)))
+    assert attempt in attempts
+


### PR DESCRIPTION
## Summary
- refine warning message in `convert_many` when no attempts are found
- detect attempts that only contain a `frames` directory
- test converting datasets lacking attempt folders

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484be58510833192a829dcaf95cbce