### PR TITLE
Fix module import for process index script

### DIFF
--- a/bias_pipeline/bias_pipeline/steps/step2_generate_master_bias_by_temp.py
+++ b/bias_pipeline/bias_pipeline/steps/step2_generate_master_bias_by_temp.py
@@ -15,7 +15,7 @@ import numpy as np
 from collections import defaultdict
 from astropy.io import fits
 from tqdm import tqdm
-from steps.utils.utils_scaling import load_fits_scaled_12bit
+from .utils.utils_scaling import load_fits_scaled_12bit
 
 def group_by_temperature(file_list, round_decimals: int = 1):
     """


### PR DESCRIPTION
## Summary
- update `step2_generate_master_bias_by_temp` to use a relative import

## Testing
- `pytest -q`
- `python process_index.py --help`

------
https://chatgpt.com/codex/tasks/task_e_684963091b888331a558e0426b2c1ead