### PR TITLE
Add irradiation dataset workflow support

### DIFF
--- a/run_calibration.py
+++ b/run_calibration.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""Run raw_to_fits, index_dataset and process_index for different dataset structures."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pandas as pd
+
+from utils import raw_to_fits, index_dataset
+import process_index
+
+
+def _run_standard(base: str, output_dir: str) -> None:
+    bias = os.path.join(base, "TestSection1")
+    dark = os.path.join(base, "TestSection2")
+    flat = os.path.join(base, "TestSection3")
+
+    raw_to_fits.convert_many(bias, dark, flat)
+    index_csv = os.path.join(base, "index.csv")
+    index_dataset.index_sections(bias, dark, flat, index_csv)
+    process_index.main(index_csv, output_dir)
+
+
+def _run_irradiation(base: str, output_dir: str) -> None:
+    stages: list[tuple[str, str]] = []
+    pre = os.path.join(base, "Preirradiation")
+    if os.path.isdir(pre):
+        stages.append((pre, "pre"))
+
+    irrad_root = os.path.join(base, "Irradiation")
+    if os.path.isdir(irrad_root):
+        for name in sorted(os.listdir(irrad_root)):
+            path = os.path.join(irrad_root, name)
+            if os.path.isdir(path):
+                stages.append((path, "during"))
+
+    post = os.path.join(base, "Postirradiation")
+    if os.path.isdir(post):
+        stages.append((post, "post"))
+
+    index_frames = []
+    for path, stage in stages:
+        bias = os.path.join(path, "Bias")
+        dark = os.path.join(path, "Darks")
+        flat = os.path.join(path, "Flats")
+
+        raw_to_fits.convert_many(bias, dark, flat, search_depth=6)
+        tmp_csv = os.path.join(path, "index.csv")
+        index_dataset.index_sections(bias, dark, flat, tmp_csv, stage=stage, search_depth=6)
+        if os.path.isfile(tmp_csv):
+            index_frames.append(pd.read_csv(tmp_csv))
+
+    if not index_frames:
+        print("No data found for irradiation structure")
+        return
+
+    combined = pd.concat(index_frames, ignore_index=True)
+    index_csv = os.path.join(base, "index.csv")
+    combined.to_csv(index_csv, index=False)
+    process_index.main(index_csv, output_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run complete calibration workflow")
+    parser.add_argument("structure", choices=["standard", "irradiation"], help="Dataset directory layout")
+    parser.add_argument("basepath", help="Path to dataset root")
+    parser.add_argument("output_dir", help="Directory for processed results")
+    args = parser.parse_args()
+
+    if args.structure == "standard":
+        _run_standard(args.basepath, args.output_dir)
+    else:
+        _run_irradiation(args.basepath, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/raw_to_fits.py
+++ b/utils/raw_to_fits.py
@@ -43,7 +43,7 @@ def read_config(path: str) -> Dict[str, str]:
 
 
 def load_csv_metadata(path: str) -> Dict[int, Dict[str, str]]:
-    """Read ``temperatureLog.csv`` and return rows indexed by ``FrameNum``."""
+    """Read ``temperatureLog.csv`` or ``radiationLog.csv`` and return rows indexed by ``FrameNum``."""
 
     rows: Dict[int, Dict[str, str]] = {}
     if not os.path.isfile(path):
@@ -226,7 +226,7 @@ def convert_attempt(
     ----------
     attempt_path: str
         Path to the attempt directory containing ``configFile.txt`` and
-        ``temperatureLog.csv``.
+        either ``temperatureLog.csv`` or ``radiationLog.csv``.
     calibration: str
         Calibration type (``BIAS``, ``DARK`` or ``FLAT``) stored in the header.
     raw_subdir: str, optional
@@ -243,6 +243,8 @@ def convert_attempt(
         config_path = os.path.join(attempt_path, "config.txt")
 
     temp_log_path = os.path.join(attempt_path, "temperatureLog.csv")
+    if not os.path.isfile(temp_log_path):
+        temp_log_path = os.path.join(attempt_path, "radiationLog.csv")
 
     raw_dir = os.path.join(attempt_path, raw_subdir)
     if not os.path.isdir(raw_dir):
@@ -317,9 +319,9 @@ def gather_attempts(root: str, max_depth: int = 2) -> List[str]:
 
     Directories named ``attempt*`` are recognised as attempts.  Additionally, if
     a directory contains a ``frames`` sub-folder along with ``configFile.txt``
-    (or ``config.txt``) and ``temperatureLog.csv`` files, it is also considered
-    an attempt so that datasets lacking explicit ``attempt`` directories are
-    supported.
+    (or ``config.txt``) and a ``temperatureLog.csv`` or ``radiationLog.csv``
+    file, it is also considered an attempt so that datasets lacking explicit
+    ``attempt`` directories are supported.
     """
 
     attempt_dirs: List[str] = []
@@ -339,7 +341,10 @@ def gather_attempts(root: str, max_depth: int = 2) -> List[str]:
             cfg_exists = os.path.isfile(os.path.join(dirpath, "configFile.txt")) or os.path.isfile(
                 os.path.join(dirpath, "config.txt")
             )
-            log_exists = os.path.isfile(os.path.join(dirpath, "temperatureLog.csv"))
+            log_exists = (
+                os.path.isfile(os.path.join(dirpath, "temperatureLog.csv"))
+                or os.path.isfile(os.path.join(dirpath, "radiationLog.csv"))
+            )
             if cfg_exists and log_exists:
                 attempt_dirs.append(dirpath)
 


### PR DESCRIPTION
## Summary
- allow `raw_to_fits` to read `radiationLog.csv`
- detect attempts when `radiationLog.csv` is present
- provide `run_calibration.py` script to convert, index and process datasets
  in both the old and irradiation directory layouts

## Testing
- `pip install -q numpy astropy matplotlib tqdm`
- `pip install -q pandas`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684992915c948331a8126ccd81443f09