### PR TITLE
Fix scatter clearing in outlier animation

### DIFF
--- a/operation_analysis.py
+++ b/operation_analysis.py
@@ -89,7 +89,8 @@ def _make_outlier_animation(frames: List[np.ndarray], times: List[float], outpat
         if coords.size:
             scatter.set_offsets(coords[:, [1, 0]])
         else:
-            scatter.set_offsets([])
+            # scatter offsets expect an (N, 2) array; use shape (0, 2) when empty
+            scatter.set_offsets(np.empty((0, 2)))
         text.set_text(f"t={times[i]:.1f}s")
         return [im, scatter, text]
 


### PR DESCRIPTION
## Summary
- fix clearing of scatter in `_make_outlier_animation`
- ensure GIF generation works without `IndexError`

## Testing
- `pytest -q`
- `python - <<'PY'
import numpy as np
from operation_analysis import _make_outlier_animation
frames=[np.zeros((5,5)), np.ones((5,5))]
times=[0,1]
_make_outlier_animation(frames, times, 'test_outliers.gif')
print('done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68499d1eea088331aed5c41f3709f9ab