### PR TITLE
Handle radiationLogCompleto metadata

### DIFF
--- a/operation_analysis.py
+++ b/operation_analysis.py
@@ -143,6 +143,8 @@ def analyze_directory(dir_path: str, output_dir: str) -> None:
 
     rad_def = _load_csv(os.path.join(dir_path, "radiationLogDef.csv"))
     rad_log = _load_csv(os.path.join(dir_path, "radiationLog.csv"))
+    if rad_log.empty:
+        rad_log = _load_csv(os.path.join(dir_path, "radiationLogCompleto.csv"))
     power_log = _load_csv(os.path.join(dir_path, "powerLog.csv"))
 
     fits_paths = _load_frames(dir_path)

--- a/tests/test_gather_attempts.py
+++ b/tests/test_gather_attempts.py
@@ -34,3 +34,15 @@ def test_gather_attempts_frames_without_attempt_dir(tmp_path):
     attempts = set(map(pathlib.Path, gather_attempts(str(root), max_depth=6)))
     assert attempt in attempts
 
+
+def test_gather_attempts_radiation_log_completo(tmp_path):
+    root = tmp_path / "TestSection2"
+    attempt = root / "T0"
+    frames = attempt / "frames"
+    frames.mkdir(parents=True)
+    (attempt / "configFile.txt").write_text("WIDTH: 1\nHEIGHT: 1\nBIT_DEPTH: 16\n")
+    (attempt / "radiationLogCompleto.csv").write_text("FrameNum\n0\n")
+
+    attempts = set(map(pathlib.Path, gather_attempts(str(root), max_depth=2)))
+    assert attempt in attempts
+

--- a/tests/test_raw_to_fits.py
+++ b/tests/test_raw_to_fits.py
@@ -62,6 +62,29 @@ def test_convert_attempt_custom_headers(tmp_path):
     assert hdr["EQTEMP"] == 5
 
 
+def test_convert_attempt_radiation_log_completo(tmp_path):
+    attempt = tmp_path / "attempt0"
+    frames = attempt / "frames"
+    frames.mkdir(parents=True)
+
+    with open(attempt / "configFile.txt", "w") as f:
+        f.write("WIDTH: 2\nHEIGHT: 2\nBIT_DEPTH: 16\n")
+
+    with open(attempt / "radiationLogCompleto.csv", "w") as f:
+        f.write(
+            "FrameNum,TimeStamp,ExtTemperature,ExpTime,RealExpTime,ExpGain,Temperature,InitialTemp\n"
+        )
+        f.write("0,100,0,12,12,1,1.5,1.4\n")
+
+    arr = np.arange(4, dtype=np.uint16).reshape(2, 2)
+    arr.tofile(frames / "f0.raw")
+
+    fits_file = convert_attempt(str(attempt), "BIAS")[0]
+    hdr = fits.getheader(fits_file)
+    assert hdr["FRAMENUM"] == 0
+    assert hdr["TEMP"] == 1.5
+
+
 def test_parse_frame_number_frame_prefix():
     assert parse_frame_number("exp_1.2e-05s_frame0.raw") == 0
 

--- a/utils/raw_to_fits.py
+++ b/utils/raw_to_fits.py
@@ -43,7 +43,7 @@ def read_config(path: str) -> Dict[str, str]:
 
 
 def load_csv_metadata(path: str) -> Dict[int, Dict[str, str]]:
-    """Read ``temperatureLog.csv`` or ``radiationLog.csv`` and return rows indexed by ``FrameNum``."""
+    """Read ``temperatureLog.csv`` or radiation logs and return rows indexed by ``FrameNum``."""
 
     rows: Dict[int, Dict[str, str]] = {}
     if not os.path.isfile(path):
@@ -245,6 +245,8 @@ def convert_attempt(
     temp_log_path = os.path.join(attempt_path, "temperatureLog.csv")
     if not os.path.isfile(temp_log_path):
         temp_log_path = os.path.join(attempt_path, "radiationLog.csv")
+    if not os.path.isfile(temp_log_path):
+        temp_log_path = os.path.join(attempt_path, "radiationLogCompleto.csv")
 
     raw_dir = os.path.join(attempt_path, raw_subdir)
     if not os.path.isdir(raw_dir):
@@ -344,6 +346,7 @@ def gather_attempts(root: str, max_depth: int = 2) -> List[str]:
             log_exists = (
                 os.path.isfile(os.path.join(dirpath, "temperatureLog.csv"))
                 or os.path.isfile(os.path.join(dirpath, "radiationLog.csv"))
+                or os.path.isfile(os.path.join(dirpath, "radiationLogCompleto.csv"))
             )
             if cfg_exists and log_exists:
                 attempt_dirs.append(dirpath)


### PR DESCRIPTION
## Summary
- support `radiationLogCompleto.csv` metadata in `raw_to_fits` and `operation_analysis`
- detect attempts that only contain `radiationLogCompleto.csv`
- test new functionality in raw-to-fits and gather_attempts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499f57938883319d0ac5d396dcd3c5