### PR TITLE
Add radiation-outlier correlation plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The repository also includes a couple of standalone scripts useful for data expl
 - **`dark_pipeline/steps/outgasing_destruction_analysis.py`** – analyses flats
   for long‑term detector degradation. It normalises frames, searches for outlier
   pixels and generates summary plots. See the script for additional options.
+- **`operation_analysis.py`** – analyses radiation exposure sequences. It now
+  correlates radiation logs with per-frame outlier counts and produces
+  `rad_vs_outliers.png` for basic sensor behaviour assessment.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- correlate radiation logs with frame outlier counts
- create `rad_vs_outliers.png` figure with a linear fit
- document new analysis in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9603a67c8331af9081575434b9aa