### PR TITLE
Enable per-dataset selection in operation_analysis

### DIFF
--- a/operation_analysis.py
+++ b/operation_analysis.py
@@ -340,9 +340,28 @@ def analyze_directory(dir_path: str, output_dir: str) -> None:
 
 
 
-def main(input_dir: str = "Operation", output_dir: str = "operation_results") -> None:
+def main(
+    input_dir: str = "Operation",
+    output_dir: str = "operation_results",
+    datasets: Optional[list[str]] = None,
+) -> None:
+    """Analyze one or more operation datasets.
+
+    Parameters
+    ----------
+    input_dir : str, optional
+        Directory containing the dataset sub-directories.
+    output_dir : str, optional
+        Destination directory for the analysis results.
+    datasets : list[str] or None, optional
+        Specific dataset sub-directories to process.  When ``None`` (default)
+        all ``*kRads`` folders inside ``input_dir`` are analyzed.
+    """
+
     os.makedirs(output_dir, exist_ok=True)
     entries = sorted(os.listdir(input_dir))
+    if datasets:
+        entries = [e for e in entries if e in datasets]
     for entry in tqdm(entries, desc="Directories", unit="dir"):
         dpath = os.path.join(input_dir, entry)
         if os.path.isdir(dpath) and _parse_rads(entry) is not None:
@@ -365,5 +384,14 @@ if __name__ == "__main__":
         default="operation_results",
         help="Directory where analysis outputs will be written",
     )
+    parser.add_argument(
+        "--datasets",
+        nargs="*",
+        default=None,
+        help=(
+            "Names of subdirectories inside input_dir to analyze. If omitted, "
+            "all <x>kRads folders are processed."
+        ),
+    )
     args = parser.parse_args()
-    main(args.input_dir, args.output_dir)
+    main(args.input_dir, args.output_dir, args.datasets)

--- a/tests/test_operation_analysis.py
+++ b/tests/test_operation_analysis.py
@@ -1,7 +1,8 @@
 import numpy as np
 from astropy.io import fits
 
-from operation_analysis import _load_frames
+from operation_analysis import _load_frames, main
+import os
 
 
 def test_load_frames_numeric_order(tmp_path):
@@ -20,3 +21,22 @@ def test_load_frames_numeric_order(tmp_path):
         str(fits_dir / "f10.fits"),
     ]
     assert _load_frames(str(attempt)) == expected
+
+
+def test_main_dataset_filter(monkeypatch, tmp_path):
+    in_dir = tmp_path / "Operation"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    (in_dir / "10kRads").mkdir()
+    (in_dir / "20kRads").mkdir()
+
+    called = []
+
+    def fake_analyze_directory(path, out):
+        called.append(os.path.basename(path))
+
+    monkeypatch.setattr("operation_analysis.analyze_directory", fake_analyze_directory)
+
+    main(str(in_dir), str(out_dir), datasets=["20kRads"])
+
+    assert called == ["20kRads"]


### PR DESCRIPTION
## Summary
- allow choosing which radiation datasets to analyse with optional `--datasets` argument
- document parameters in `main` and update CLI
- test dataset filtering in operation_analysis

## Testing
- `pip install numpy astropy matplotlib tqdm pandas pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a92c21f408331b245c522d5739f79