### PR TITLE
Handle polyfit errors in intensity stats

### DIFF
--- a/operation_analysis.py
+++ b/operation_analysis.py
@@ -251,8 +251,18 @@ def _plot_intensity_stats(
     m = np.array(means, dtype=float)
     s = np.array(stds, dtype=float)
 
-    mean_fit = np.polyfit(t, m, 1) if len(t) > 1 else (0.0, m[0])
-    std_fit = np.polyfit(t, s, 1) if len(t) > 1 else (0.0, s[0])
+    if len(t) > 1:
+        try:
+            mean_fit = np.polyfit(t, m, 1)
+        except np.linalg.LinAlgError:
+            mean_fit = (0.0, float(np.mean(m)))
+        try:
+            std_fit = np.polyfit(t, s, 1)
+        except np.linalg.LinAlgError:
+            std_fit = (0.0, float(np.mean(s)))
+    else:
+        mean_fit = (0.0, float(np.mean(m)))
+        std_fit = (0.0, float(np.mean(s)))
     trend_t = np.array([t[0], t[-1]])
 
     plt.figure(figsize=(8, 4))

--- a/tests/test_operation_analysis.py
+++ b/tests/test_operation_analysis.py
@@ -1,7 +1,7 @@
 import numpy as np
 from astropy.io import fits
 
-from operation_analysis import _load_frames, main
+from operation_analysis import _load_frames, main, _plot_intensity_stats
 import os
 
 
@@ -40,3 +40,20 @@ def test_main_dataset_filter(monkeypatch, tmp_path):
     main(str(in_dir), str(out_dir), datasets=["20kRads"])
 
     assert called == ["20kRads"]
+
+
+def test_plot_intensity_stats_polyfit_failure(monkeypatch, tmp_path):
+    out = tmp_path / "plot.png"
+
+    means = [1.0, 2.0, 3.0]
+    stds = [0.1, 0.2, 0.3]
+    times = [0.0, 1.0, 2.0]
+
+    def raise_linalg(*args, **kwargs):
+        raise np.linalg.LinAlgError("fail")
+
+    monkeypatch.setattr(np, "polyfit", raise_linalg)
+
+    _plot_intensity_stats(means, stds, times, str(out))
+
+    assert out.exists()


### PR DESCRIPTION
## Summary
- guard against `np.polyfit` failures when calculating intensity metrics
- test polyfit fallback when a linear algebra error occurs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a98cacb688331864c4cdc5b3e1bd0