### PR TITLE
Avoid duplicate fits conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ For irradiation campaigns:
 ```bash
 python run_calibration.py irradiation path/to/irrad_dataset output_dir/
 ```
+In this mode the script inspects every ``Bias``, ``Darks`` and ``Flats``
+folder. Raw-to-FITS conversion is only executed when no ``fits/``
+directory with FITS files is present so previously converted data is not
+processed again.
 
 The script writes an ``index.csv`` file in the dataset root and fills the
 given output directory with the generated masters, the


### PR DESCRIPTION
## Summary
- skip raw->FITS conversion in `run_calibration._run_irradiation` if FITS already exist
- document the skipping behaviour for irradiation datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acf8ed63c83318b543233d403c4f2