### PR TITLE
Improve radiation dose analysis plots and precision

### DIFF
--- a/dose_analysis.py
+++ b/dose_analysis.py
@@ -99,6 +99,15 @@ def _make_master(paths: List[str]) -> Tuple[np.ndarray, fits.Header]:
     return master, hdr
 
 
+def _stack_stats(paths: List[str]) -> Tuple[np.ndarray, np.ndarray]:
+    """Return per-pixel mean and standard deviation for *paths*."""
+    stack = [fits.getdata(p).astype(np.float32) for p in paths]
+    arr = np.stack(stack, axis=0)
+    mean = np.mean(arr, axis=0)
+    std = np.std(arr, axis=0)
+    return mean, std
+
+
 def _group_paths(df: pd.DataFrame) -> Dict[Tuple[str, str, float, float | None], List[str]]:
     groups: Dict[Tuple[str, str, float, float | None], List[str]] = defaultdict(list)
     during_doses: List[float] = []
@@ -151,7 +160,8 @@ def _save_plot(summary: pd.DataFrame, outdir: str) -> None:
             if sub.empty:
                 continue
 
-            plt.figure()
+            fig, ax = plt.subplots()
+            stats_lines = []
             for stage in ("pre", "during", "post"):
                 stage_df = sub[sub["STAGE"] == stage]
                 if stage_df.empty:
@@ -164,23 +174,27 @@ def _save_plot(summary: pd.DataFrame, outdir: str) -> None:
                 y = y.iloc[order]
                 e = e.iloc[order]
                 fmt = "o" if len(x) == 1 else "-o"
-                plt.errorbar(x, y, yerr=e, fmt=fmt, label=stage)
+                ax.errorbar(x, y, yerr=e, fmt=fmt, label=stage)
+                ax.fill_between(x, y - e, y + e, alpha=0.2)
+                stats_lines.append(f"{stage}: \u03BC={y.mean():.1f}, \u03C3={e.mean():.1f}")
 
-            plt.xlabel("Dose [kRad]")
-            plt.ylabel("Mean ADU")
+            ax.set_xlabel("Dose [kRad]")
+            ax.set_ylabel("Mean ADU")
             title = cal
             if exp is not None:
                 title += f" E={exp:g}s"
-            plt.title(title)
-            plt.legend()
-            plt.tight_layout()
+            ax.set_title(title)
+            ax.legend()
+            ax.grid(True, which="both", ls="--", alpha=0.5)
+            fig.text(1.02, 0.5, "\n".join(stats_lines), va="center")
+            fig.tight_layout()
 
             fname = f"{cal.lower()}_mean_vs_dose"
             if exp is not None:
                 fname += f"_E{str(exp).replace('.', 'p')}s"
             fname += ".png"
-            plt.savefig(os.path.join(outdir, fname))
-            plt.close()
+            fig.savefig(os.path.join(outdir, fname))
+            plt.close(fig)
 
 
 def _compute_photometric_precision(summary: pd.DataFrame) -> pd.DataFrame:
@@ -210,14 +224,145 @@ def _plot_photometric_precision(df: pd.DataFrame, outdir: str) -> None:
         return
     os.makedirs(outdir, exist_ok=True)
     df = df.sort_values("DOSE")
-    plt.figure()
-    plt.plot(df["DOSE"], df["MAG_ERR"], marker="o")
-    plt.xlabel("Dose [kRad]")
-    plt.ylabel("Magnitude error [mag]")
-    plt.title("Photometric precision during irradiation")
-    plt.tight_layout()
-    plt.savefig(os.path.join(outdir, "photometric_precision_vs_dose.png"))
-    plt.close()
+    fig, ax = plt.subplots()
+    ax.plot(df["DOSE"], df["MAG_ERR"], marker="o")
+    ax.set_xlabel("Dose [kRad]")
+    ax.set_ylabel("Magnitude error [mag]")
+    ax.set_title("Photometric precision during irradiation")
+    ax.grid(True, which="both", ls="--", alpha=0.5)
+    stats = f"min={df['MAG_ERR'].min():.3f}\nmax={df['MAG_ERR'].max():.3f}"
+    fig.text(1.02, 0.5, stats, va="center")
+    fig.tight_layout()
+    fig.savefig(os.path.join(outdir, "photometric_precision_vs_dose.png"))
+    plt.close(fig)
+
+
+def _pixel_precision_analysis(groups: Dict[Tuple[str, str, float, float | None], List[str]], outdir: str) -> None:
+    """Generate per-pixel magnitude and ADU error maps for each dose."""
+    bias_groups = {k: v for k, v in groups.items() if k[0] == "during" and k[1] == "BIAS"}
+    dark_groups = {k: v for k, v in groups.items() if k[0] == "during" and k[1] == "DARK"}
+    doses = sorted(set(k[2] for k in bias_groups) & set(k[2] for k in dark_groups))
+    if not doses:
+        return
+
+    os.makedirs(outdir, exist_ok=True)
+    zone_labels = ["Q1", "Q2", "Q3", "Q4"]
+    zone_mag: Dict[str, List[Tuple[float, float]]] = {z: [] for z in zone_labels}
+    zone_adu: Dict[str, List[Tuple[float, float]]] = {z: [] for z in zone_labels}
+
+    for d in doses:
+        b_paths = [p for k, v in bias_groups.items() if k[2] == d for p in v]
+        d_paths = [p for k, v in dark_groups.items() if k[2] == d for p in v]
+        if not b_paths or not d_paths:
+            continue
+
+        b_mean, b_std = _stack_stats(b_paths)
+        _, d_std = _stack_stats(d_paths)
+        full_scale = 4096 * 16.0
+        signal = (full_scale - b_mean) / 2.0
+        noise = np.sqrt(np.maximum(signal, 0) + b_std ** 2 + d_std ** 2)
+        snr = np.where(noise > 0, signal / noise, 0.0)
+        mag_err = np.where(snr > 0, 1.0857 / snr, np.inf)
+        adu_err16 = noise
+        adu_err12 = noise / 16.0
+
+        tag = f"{d:g}kR"
+        fits.writeto(os.path.join(outdir, f"mag_err_{tag}.fits"), mag_err.astype(np.float32), overwrite=True)
+        fits.writeto(os.path.join(outdir, f"adu_err16_{tag}.fits"), adu_err16.astype(np.float32), overwrite=True)
+        fits.writeto(os.path.join(outdir, f"adu_err12_{tag}.fits"), adu_err12.astype(np.float32), overwrite=True)
+
+        h, w = mag_err.shape
+        my, mx = h // 2, w // 2
+        zones = [
+            (slice(0, my), slice(0, mx)),
+            (slice(0, my), slice(mx, None)),
+            (slice(my, None), slice(0, mx)),
+            (slice(my, None), slice(mx, None)),
+        ]
+        for label, (ys, xs) in zip(zone_labels, zones):
+            zone_mag[label].append((d, float(np.mean(mag_err[ys, xs]))))
+            zone_adu[label].append((d, float(np.mean(adu_err16[ys, xs]))))
+
+    # Zone plots
+    fig_m, ax_m = plt.subplots()
+    for label, vals in zone_mag.items():
+        if not vals:
+            continue
+        doses = [v[0] for v in vals]
+        errs = [v[1] for v in vals]
+        ax_m.plot(doses, errs, marker="o", label=label)
+    ax_m.set_xlabel("Dose [kRad]")
+    ax_m.set_ylabel("Magnitude error [mag]")
+    ax_m.set_title("Per-zone magnitude error")
+    ax_m.legend()
+    ax_m.grid(True, ls="--", alpha=0.5)
+    fig_m.tight_layout()
+    fig_m.savefig(os.path.join(outdir, "zone_mag_error.png"))
+    plt.close(fig_m)
+
+    fig_a, ax_a = plt.subplots()
+    for label, vals in zone_adu.items():
+        if not vals:
+            continue
+        doses = [v[0] for v in vals]
+        errs = [v[1] for v in vals]
+        ax_a.plot(doses, errs, marker="o", label=label)
+    ax_a.set_xlabel("Dose [kRad]")
+    ax_a.set_ylabel("ADU error (16 bit)")
+    ax_a.set_title("Per-zone ADU error")
+    ax_a.legend()
+    ax_a.grid(True, ls="--", alpha=0.5)
+    fig_a.tight_layout()
+    fig_a.savefig(os.path.join(outdir, "zone_adu_error.png"))
+    plt.close(fig_a)
+
+
+def _compare_stage_differences(summary: pd.DataFrame, outdir: str) -> None:
+    """Store differences between initial/last irradiation values and pre/post."""
+    df = summary
+    during = df[df["STAGE"] == "during"]
+    pre = df[df["STAGE"] == "pre"]
+    post = df[df["STAGE"] == "post"]
+    if during.empty:
+        return
+    min_dose = during["DOSE"].min()
+    max_dose = during["DOSE"].max()
+
+    rows = []
+    for cal in ("BIAS", "DARK"):
+        dmin = during[(during["CALTYPE"] == cal) & (during["DOSE"] == min_dose)]
+        dmax = during[(during["CALTYPE"] == cal) & (during["DOSE"] == max_dose)]
+        p_pre = pre[pre["CALTYPE"] == cal]
+        p_post = post[post["CALTYPE"] == cal]
+        if not dmin.empty and not p_pre.empty:
+            diff = float(dmin["MEAN"].mean() - p_pre["MEAN"].mean())
+            rows.append({"CALTYPE": cal, "CMP": "first_vs_pre", "DIFF": diff})
+        if not dmax.empty and not p_post.empty:
+            diff = float(p_post["MEAN"].mean() - dmax["MEAN"].mean())
+            rows.append({"CALTYPE": cal, "CMP": "post_vs_last", "DIFF": diff})
+
+    if rows:
+        os.makedirs(outdir, exist_ok=True)
+        pd.DataFrame(rows).to_csv(os.path.join(outdir, "stage_differences.csv"), index=False)
+
+
+def _fit_dose_response(summary: pd.DataFrame, outdir: str) -> None:
+    """Fit a linear model of mean value vs dose and store coefficients."""
+    df = summary[summary["STAGE"] == "during"]
+    if df.empty:
+        return
+    os.makedirs(outdir, exist_ok=True)
+    rows = []
+    for cal in df["CALTYPE"].unique():
+        sub = df[df["CALTYPE"] == cal]
+        x = sub["DOSE"].astype(float)
+        y = sub["MEAN"].astype(float)
+        if len(x) < 2:
+            continue
+        coeff = np.polyfit(x, y, 1)
+        rows.append({"CALTYPE": cal, "SLOPE": float(coeff[0]), "INTERCEPT": float(coeff[1])})
+    if rows:
+        pd.DataFrame(rows).to_csv(os.path.join(outdir, "dose_model.csv"), index=False)
 
 def main(index_csv: str, output_dir: str) -> None:
     df = pd.read_csv(index_csv)
@@ -248,6 +393,10 @@ def main(index_csv: str, output_dir: str) -> None:
     summary.to_csv(summary_csv, index=False)
 
     _save_plot(summary, os.path.join(output_dir, "plots"))
+
+    _pixel_precision_analysis(groups, os.path.join(output_dir, "pixel_precision"))
+    _compare_stage_differences(summary, os.path.join(output_dir, "analysis"))
+    _fit_dose_response(summary, os.path.join(output_dir, "analysis"))
 
     precision_df = _compute_photometric_precision(summary)
     precision_csv = os.path.join(output_dir, "photometric_precision.csv")

--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -58,11 +58,12 @@ def test_save_plot_all_stages(monkeypatch, tmp_path):
 
     labels = []
 
-    def fake_errorbar(x, y, yerr=None, fmt=None, label=None, **k):
+    def fake_errorbar(self, x, y, yerr=None, fmt=None, label=None, **k):
         labels.append(label)
 
-    monkeypatch.setattr('matplotlib.pyplot.errorbar', fake_errorbar)
-    monkeypatch.setattr('matplotlib.pyplot.savefig', lambda *a, **k: None)
+    monkeypatch.setattr('matplotlib.axes.Axes.errorbar', fake_errorbar)
+    monkeypatch.setattr('matplotlib.axes.Axes.fill_between', lambda *a, **k: None)
+    monkeypatch.setattr('matplotlib.figure.Figure.savefig', lambda *a, **k: None)
 
     _save_plot(summary, tmp_path)
 


### PR DESCRIPTION
## Summary
- enhance dose plots with grid, fill-between and stats text
- compute per-pixel magnitude and ADU precision by dose
- export zone-wise error plots and dose statistics
- compare stages and fit simple linear dose model
- update test for new plotting behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ae6c115c08331a939971b128d7f7c