### PR TITLE
Add PNG output to pixel precision analysis

### DIFF
--- a/dose_analysis.py
+++ b/dose_analysis.py
@@ -271,6 +271,30 @@ def _pixel_precision_analysis(groups: Dict[Tuple[str, str, float, float | None],
         fits.writeto(os.path.join(outdir, f"adu_err16_{tag}.fits"), adu_err16.astype(np.float32), overwrite=True)
         fits.writeto(os.path.join(outdir, f"adu_err12_{tag}.fits"), adu_err12.astype(np.float32), overwrite=True)
 
+        plt.figure(figsize=(6, 5))
+        im = plt.imshow(mag_err, origin="lower", cmap="magma")
+        plt.colorbar(im, label="Magnitude error [mag]")
+        plt.title(f"Magnitude error {tag}")
+        plt.tight_layout()
+        plt.savefig(os.path.join(outdir, f"mag_err_{tag}.png"))
+        plt.close()
+
+        plt.figure(figsize=(6, 5))
+        im = plt.imshow(adu_err16, origin="lower", cmap="viridis")
+        plt.colorbar(im, label="ADU error (16 bit)")
+        plt.title(f"ADU error 16-bit {tag}")
+        plt.tight_layout()
+        plt.savefig(os.path.join(outdir, f"adu_err16_{tag}.png"))
+        plt.close()
+
+        plt.figure(figsize=(6, 5))
+        im = plt.imshow(adu_err12, origin="lower", cmap="viridis")
+        plt.colorbar(im, label="ADU error (12 bit)")
+        plt.title(f"ADU error 12-bit {tag}")
+        plt.tight_layout()
+        plt.savefig(os.path.join(outdir, f"adu_err12_{tag}.png"))
+        plt.close()
+
         h, w = mag_err.shape
         my, mx = h // 2, w // 2
         zones = [

--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -8,6 +8,7 @@ from dose_analysis import (
     _make_master,
     _compute_photometric_precision,
     _save_plot,
+    _pixel_precision_analysis,
 )
 
 
@@ -81,4 +82,23 @@ def test_compute_photometric_precision():
     df = _compute_photometric_precision(summary)
     assert set(df['DOSE']) == {1.0, 2.0}
     assert df['MAG_ERR'].iloc[0] < df['MAG_ERR'].iloc[1]
+
+
+def test_pixel_precision_analysis_generates_maps(tmp_path):
+    bias = tmp_path / 'b.fits'
+    dark = tmp_path / 'd.fits'
+    _make_fits(bias, 1000)
+    _make_fits(dark, 10)
+
+    groups = {
+        ('during', 'BIAS', 1.0, None): [str(bias)],
+        ('during', 'DARK', 1.0, None): [str(dark)],
+    }
+
+    out_dir = tmp_path / 'out'
+    _pixel_precision_analysis(groups, str(out_dir))
+
+    assert (out_dir / 'mag_err_1kR.png').is_file()
+    assert (out_dir / 'adu_err16_1kR.png').is_file()
+    assert (out_dir / 'adu_err12_1kR.png').is_file()
 


### PR DESCRIPTION
## Summary
- generate PNG plots for mag/ADU error maps in `_pixel_precision_analysis`
- test that PNG outputs are created

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aec9669c883319c84358af7d38da9