### PR TITLE
Add magnitude error std to photometric precision

### DIFF
--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -7,6 +7,7 @@ from dose_analysis import (
     _group_paths,
     _make_master,
     _compute_photometric_precision,
+    _plot_photometric_precision,
     _save_plot,
 )
 
@@ -81,4 +82,26 @@ def test_compute_photometric_precision():
     df = _compute_photometric_precision(summary)
     assert set(df['DOSE']) == {1.0, 2.0}
     assert df['MAG_ERR'].iloc[0] < df['MAG_ERR'].iloc[1]
+    assert "MAG_ERR_STD" in df.columns
+
+
+def test_plot_photometric_precision(monkeypatch, tmp_path):
+    df = pd.DataFrame({
+        "DOSE": [1.0, 2.0],
+        "MAG_ERR": [0.1, 0.2],
+        "MAG_ERR_STD": [0.01, 0.02],
+    })
+
+    yerrs = []
+
+    def fake_errorbar(self, x, y, yerr=None, fmt=None, **k):
+        yerrs.append(yerr)
+
+    monkeypatch.setattr("matplotlib.axes.Axes.errorbar", fake_errorbar)
+    monkeypatch.setattr("matplotlib.figure.Figure.savefig", lambda *a, **k: None)
+
+    _plot_photometric_precision(df, tmp_path)
+
+    assert len(yerrs) == 1
+    assert np.allclose(yerrs[0], df["MAG_ERR_STD"]) 
 


### PR DESCRIPTION
## Summary
- extend `_compute_photometric_precision` to return MAG_ERR_STD
- plot new std deviation with error bars in `_plot_photometric_precision`
- update unit tests for new behaviour and add test for plotting function

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aeccd68bc8331b6ad423985c66095