### PR TITLE
Add global pixel precision stats and plotting

### DIFF
--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -119,9 +119,13 @@ def test_pixel_precision_analysis_generates_maps(tmp_path):
     }
 
     out_dir = tmp_path / 'out'
-    _pixel_precision_analysis(groups, str(out_dir))
+    stats = _pixel_precision_analysis(groups, str(out_dir))
 
     assert (out_dir / 'mag_err_1kR.png').is_file()
     assert (out_dir / 'adu_err16_1kR.png').is_file()
     assert (out_dir / 'adu_err12_1kR.png').is_file()
+    assert (out_dir / 'mag_err_vs_dose.png').is_file()
+    assert (out_dir / 'adu_err_vs_dose.png').is_file()
+    assert set(stats.columns) == {"DOSE", "MAG_MEAN", "MAG_STD", "ADU_MEAN", "ADU_STD"}
+    assert len(stats) == 1
 


### PR DESCRIPTION
## Summary
- extend `_pixel_precision_analysis` to compute mean/std errors per dose
- add `_plot_error_vs_dose` to visualise global magnitude and ADU errors
- write pixel precision stats to CSV and return DataFrame
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aedc3aa6483319d5b67dd4226407c