### PR TITLE
Add stage comparison heatmaps

### DIFF
--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -11,6 +11,8 @@ from dose_analysis import (
     _plot_photometric_precision,
     _save_plot,
     _fit_dose_response,
+    _compare_stage_differences,
+    _pixel_precision_analysis,
 )
 
 
@@ -150,4 +152,29 @@ def test_fit_dose_response_outputs(tmp_path, monkeypatch):
 
     assert (tmp_path / "dose_model.csv").exists()
     assert sorted(saved) == ["dose_model_bias.png", "dose_model_dark.png"]
+
+
+def test_compare_stage_differences_generates_heatmaps(tmp_path):
+    master_dir = tmp_path / "masters"
+    out_dir = tmp_path / "out"
+    master_dir.mkdir()
+
+    # create masters for bias
+    _make_fits(master_dir / "master_bias_pre_D1kR_E1.0.fits", 1)
+    _make_fits(master_dir / "master_bias_during_D1kR_E1.0.fits", 2)
+    _make_fits(master_dir / "master_bias_during_D5kR_E1.0.fits", 5)
+    _make_fits(master_dir / "master_bias_post_D5kR_E1.0.fits", 4)
+
+    summary = pd.DataFrame([
+        {"STAGE": "pre", "CALTYPE": "BIAS", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 1.0, "STD": 0.0},
+        {"STAGE": "during", "CALTYPE": "BIAS", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 2.0, "STD": 0.0},
+        {"STAGE": "during", "CALTYPE": "BIAS", "DOSE": 5.0, "EXPTIME": 1.0, "MEAN": 5.0, "STD": 0.0},
+        {"STAGE": "post", "CALTYPE": "BIAS", "DOSE": 5.0, "EXPTIME": 1.0, "MEAN": 4.0, "STD": 0.0},
+    ])
+
+    _compare_stage_differences(summary, str(master_dir), str(out_dir))
+
+    assert (out_dir / "stage_differences.csv").is_file()
+    assert (out_dir / "bias_first_vs_pre.png").is_file()
+    assert (out_dir / "bias_post_vs_last.png").is_file()
 


### PR DESCRIPTION
## Summary
- generate heatmaps for differences between stages in `dose_analysis`
- update main function to pass master directory
- test that heatmaps are produced

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aef311d6c833186f1beedf2cdc33c