### PR TITLE
Handle exposure in dark dose model

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The repository also includes a couple of standalone scripts useful for data expl
   `rad_vs_outliers.png` for basic sensor behaviour assessment. The
   linear fit on this plot now gracefully falls back to a constant line
   if a polynomial fit cannot be computed.
+- **`dose_analysis.py`** – groups calibration frames by radiation dose and now
+  fits a dose-response for dark current at each exposure time.
 
 ## Installation
 

--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -139,6 +139,8 @@ def test_fit_dose_response_outputs(tmp_path, monkeypatch):
         {"STAGE": "during", "CALTYPE": "BIAS", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 2.0, "STD": 0.1},
         {"STAGE": "during", "CALTYPE": "DARK", "DOSE": 0.0, "EXPTIME": 1.0, "MEAN": 10.0, "STD": 0.1},
         {"STAGE": "during", "CALTYPE": "DARK", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 12.0, "STD": 0.1},
+        {"STAGE": "during", "CALTYPE": "DARK", "DOSE": 0.0, "EXPTIME": 2.0, "MEAN": 20.0, "STD": 0.1},
+        {"STAGE": "during", "CALTYPE": "DARK", "DOSE": 1.0, "EXPTIME": 2.0, "MEAN": 24.0, "STD": 0.1},
     ])
 
     saved = []
@@ -151,7 +153,11 @@ def test_fit_dose_response_outputs(tmp_path, monkeypatch):
     _fit_dose_response(summary, tmp_path)
 
     assert (tmp_path / "dose_model.csv").exists()
-    assert sorted(saved) == ["dose_model_bias.png", "dose_model_dark.png"]
+    assert sorted(saved) == [
+        "dose_model_bias.png",
+        "dose_model_dark_E1p0s.png",
+        "dose_model_dark_E2p0s.png",
+    ]
 
 
 def test_compare_stage_differences_generates_heatmaps(tmp_path):


### PR DESCRIPTION
## Summary
- extend `dose_analysis._fit_dose_response` to model DARK frames
  separately for every exposure time
- adapt figure naming scheme to include exposure time
- update documentation mentioning `dose_analysis.py`
- test the new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684af1800a1083318ea96bdcdf5f7788