### PR TITLE
Add base level dose trend analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ The repository also includes a couple of standalone scripts useful for data expl
   `rad_vs_outliers.png` for basic sensor behaviour assessment. The
   linear fit on this plot now gracefully falls back to a constant line
   if a polynomial fit cannot be computed.
-- **`dose_analysis.py`** – groups calibration frames by radiation dose and now
-  fits a dose-response for dark current at each exposure time.
+- **`dose_analysis.py`** – groups calibration frames by radiation dose,
+  fits a dose-response for dark current at each exposure time and now also
+  fits linear base level trends for bias and dark frames. The coefficients are
+  written to `analysis/base_level_trend.csv` alongside the corresponding plots.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- compute base level trend of mean bias/dark vs dose
- save coefficients in `analysis/base_level_trend.csv`
- generate fit plots for bias and dark mean vs dose
- document new outputs in README
- test base level trend helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bef1b785c8331934dc0d445c45b1a