### PR TITLE
Add stage base level difference analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ The repository also includes a couple of standalone scripts useful for data expl
   fits a dose-response for dark current at each exposure time and now also
   fits linear base level trends for bias and dark frames. The coefficients are
   written to `analysis/base_level_trend.csv` alongside the corresponding plots.
+  It also compares the first/last irradiation base levels with the pre/post
+  values, saving the differences versus dose in `analysis/stage_base_diff.npz`
+  and the accompanying figures.
+
+The stored differences indicate how much the detector baseline shifts when
+irradiation begins and how much of that shift remains once the source is turned
+off. Positive values mean the radiating stage has a higher mean level than the
+reference stage.
 
 ## Installation
 

--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -12,6 +12,7 @@ from dose_analysis import (
     _save_plot,
     _fit_dose_response,
     _fit_base_level_trend,
+    _stage_base_level_diff,
     _compare_stage_differences,
     _pixel_precision_analysis,
     _dynamic_range_analysis,
@@ -238,5 +239,27 @@ def test_fit_base_level_trend_outputs(tmp_path, monkeypatch):
         "base_level_trend_bias.png",
         "base_level_trend_dark.png",
     ]
+
+
+def test_stage_base_level_diff_outputs(tmp_path):
+    summary = pd.DataFrame([
+        {"STAGE": "pre", "CALTYPE": "BIAS", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 10.0, "STD": 0.1},
+        {"STAGE": "radiating", "CALTYPE": "BIAS", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 12.0, "STD": 0.1},
+        {"STAGE": "radiating", "CALTYPE": "BIAS", "DOSE": 5.0, "EXPTIME": 1.0, "MEAN": 14.0, "STD": 0.1},
+        {"STAGE": "post", "CALTYPE": "BIAS", "DOSE": 5.0, "EXPTIME": 1.0, "MEAN": 13.0, "STD": 0.1},
+        {"STAGE": "pre", "CALTYPE": "DARK", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 20.0, "STD": 0.1},
+        {"STAGE": "radiating", "CALTYPE": "DARK", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 22.0, "STD": 0.1},
+        {"STAGE": "radiating", "CALTYPE": "DARK", "DOSE": 5.0, "EXPTIME": 1.0, "MEAN": 25.0, "STD": 0.1},
+        {"STAGE": "post", "CALTYPE": "DARK", "DOSE": 5.0, "EXPTIME": 1.0, "MEAN": 24.0, "STD": 0.1},
+    ])
+
+    df = _stage_base_level_diff(summary, tmp_path)
+
+    assert (tmp_path / "stage_base_diff.npz").is_file()
+    assert (tmp_path / "stage_base_diff_bias.png").is_file()
+    assert (tmp_path / "stage_base_diff_dark.png").is_file()
+
+    assert set(df["CALTYPE"]) == {"BIAS", "DARK"}
+    assert set(df["CMP"]) == {"first_pre", "last_post"}
 
 


### PR DESCRIPTION
## Summary
- compute base level differences between the first radiating frame and pre stage
- compute base level differences between last radiating frame and post stage
- plot these differences versus dose, save in `stage_base_diff.npz`
- expose new helper in dose analysis and test it
- document new outputs and meaning in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf100a0f48331bd34c6ab95efedc9