### PR TITLE
Improve dynamic range plots

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -22,11 +22,11 @@ per-dose means.
 
 Dynamic range reduction plots
 -----------------------------
-`dynamic_range_vs_dose.png` shows how the available range decreases with dose.
-The plot includes two curves: the remaining range assuming a 16‑bit detector
-(blue circles) and a 12‑bit detector (orange squares). Dashed horizontal lines
-mark the ideal maximum ranges (65536 ADU and 4096 ADU respectively). Reading the
-plot from left to right reveals how much of the range is lost as dose increases.
+`dynamic_range_vs_dose_16.png` and `dynamic_range_vs_dose_12.png` show how the
+available range decreases with dose for 16‑bit and 12‑bit readout
+respectively.  Each figure includes a subplot with the percentage reduction
+relative to the corresponding ideal range (65536 ADU or 4096 ADU).  A shaded
+region illustrates the one sigma uncertainty of the dynamic range.
 
 Slope of the base level increase
 --------------------------------

--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -202,7 +202,8 @@ def test_dynamic_range_analysis_outputs(tmp_path):
 
     df = _dynamic_range_analysis(summary, str(tmp_path))
 
-    assert (tmp_path / "dynamic_range_vs_dose.png").is_file()
+    assert (tmp_path / "dynamic_range_vs_dose_16.png").is_file()
+    assert (tmp_path / "dynamic_range_vs_dose_12.png").is_file()
     assert (tmp_path / "dynamic_range.npz").is_file()
     assert set(df.columns) == {
         "DOSE",
@@ -212,6 +213,8 @@ def test_dynamic_range_analysis_outputs(tmp_path):
         "DR_12",
         "NOISE_ADU",
         "NOISE_MAG",
+        "RED_16",
+        "RED_12",
     }
     row = df.iloc[0]
     expected_noise = np.sqrt(1.0 ** 2 + 2.0 ** 2)
@@ -219,6 +222,7 @@ def test_dynamic_range_analysis_outputs(tmp_path):
     assert np.isclose(row["DARK_MEAN"], 5.0)
     assert np.isclose(row["DR_16"], 65536 - 15.0)
     assert np.isclose(row["NOISE_ADU"], expected_noise)
+    assert np.isclose(row["RED_16"], 100 * 15.0 / 65536.0)
 
 
 def test_fit_base_level_trend_outputs(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- show 16-bit and 12-bit dynamic range separately
- add percentage reduction subplot and standard deviation shading
- update README description
- adjust dynamic range test for new plots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf70f9e0083318d96c7c2d5d86d0c