### PR TITLE
Update dynamic range analysis with 12‑bit scaling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,10 @@ This README summarises the radiation dose analysis utilities.
 Noise estimation
 ----------------
 The `dose_analysis.py` script computes dynamic range and noise for each
-irradiation dose. The noise in ADU is obtained from the quadratic sum of the
-per-dose bias and dark standard deviations:
+irradiation dose. Images are stored in 16‑bit FITS files but the detector
+itself has a 12‑bit digitisation. Counts are therefore scaled by a factor of
+16 when written to disk. The noise in ADU is obtained from the quadratic sum of
+the per-dose bias and dark standard deviations:
 
 ```
 noise = sqrt(bias_std**2 + dark_std**2)
@@ -26,7 +28,14 @@ Dynamic range reduction plots
 available range decreases with dose for 16‑bit and 12‑bit readout
 respectively.  Each figure includes a subplot with the percentage reduction
 relative to the corresponding ideal range (65536 ADU or 4096 ADU).  A shaded
-region illustrates the one sigma uncertainty of the dynamic range.
+region illustrates the one sigma uncertainty of the dynamic range.  Additional
+figures `baseline_vs_dose_16.png` and `baseline_vs_dose_12.png` display the
+minimum recorded level (bias + dark) against the maximum count of the ADC for
+both scales in order to visualise the available range directly.
+
+`magnitude_vs_dose.png` combines the estimated magnitude error caused by
+radiation with the loss of reachable magnitude due to the shrinking dynamic
+range.
 
 Slope of the base level increase
 --------------------------------
@@ -44,12 +53,14 @@ Several helper arrays are stored in the analysis directory:
   `_dynamic_range_analysis`.
 * `stage_base_diff.npz` – baseline differences between irradiation stages from
   `_stage_base_level_diff`.
+  The `dynamic_range.npz` file now also stores the baseline levels in both
+  16‑bit and 12‑bit units for every dose.
 
 Load these files with `numpy.load` for custom plotting or further processing:
 
 ```python
 arr = np.load('analysis/dynamic_range.npz')
-print(arr['dose'], arr['noise_adu'])
+print(arr['dose'], arr['noise_adu'], arr['base_level_16'])
 ```
 
 The arrays correspond to the plots produced by the script and can be reused to

--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -215,6 +215,8 @@ def test_dynamic_range_analysis_outputs(tmp_path):
         "NOISE_MAG",
         "RED_16",
         "RED_12",
+        "BASE_16",
+        "BASE_12",
     }
     row = df.iloc[0]
     expected_noise = np.sqrt(1.0 ** 2 + 2.0 ** 2)


### PR DESCRIPTION
## Summary
- account for 12‑bit data stored in 16‑bit when analysing dynamic range
- plot baseline level vs available counts in both 16‑ and 12‑bit units
- show magnitude error and lost magnitude range as dose increases
- include baseline arrays in `dynamic_range.npz`
- document new behaviour in `README.txt`
- adjust unit tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bfd777e0883318143153e7ada5855