### PR TITLE
Support multiple stages in dynamic range analysis

### DIFF
--- a/dose_analysis.py
+++ b/dose_analysis.py
@@ -844,7 +844,7 @@ def _dynamic_range_analysis(summary: pd.DataFrame, outdir: str) -> pd.DataFrame:
         data is missing.
     """
 
-    df = summary[summary["STAGE"] == "during"]
+    df = summary[summary["STAGE"].isin(["radiating", "during"])]
     bias = df[df["CALTYPE"] == "BIAS"]
     dark = df[df["CALTYPE"] == "DARK"]
     doses = sorted(set(bias["DOSE"]) & set(dark["DOSE"]))

--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -197,8 +197,8 @@ def test_compare_stage_differences_generates_heatmaps(tmp_path):
 
 def test_dynamic_range_analysis_outputs(tmp_path):
     summary = pd.DataFrame([
-        {"STAGE": "during", "CALTYPE": "BIAS", "DOSE": 1.0, "EXPTIME": 0.0, "MEAN": 10.0, "STD": 1.0},
-        {"STAGE": "during", "CALTYPE": "DARK", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 5.0, "STD": 2.0},
+        {"STAGE": "radiating", "CALTYPE": "BIAS", "DOSE": 1.0, "EXPTIME": 0.0, "MEAN": 10.0, "STD": 1.0},
+        {"STAGE": "radiating", "CALTYPE": "DARK", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 5.0, "STD": 2.0},
     ])
 
     df = _dynamic_range_analysis(summary, str(tmp_path))


### PR DESCRIPTION
## Summary
- allow `_dynamic_range_analysis` to consider both "radiating" and "during" stages
- update test to use the "radiating" stage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c0452fe3883319df1aeaff61b0257