### PR TITLE
Allow radiating dynamic range analysis

### DIFF
--- a/dose_analysis.py
+++ b/dose_analysis.py
@@ -1053,7 +1053,7 @@ def _dynamic_range_analysis(summary: pd.DataFrame, outdir: str) -> pd.DataFrame:
         data is missing.
     """
 
-    df = summary[summary["STAGE"].isin(["radiating", "during"])]
+    df = summary[summary["STAGE"].isin({"radiating", "during"})]
     bias = df[df["CALTYPE"] == "BIAS"]
     dark = df[df["CALTYPE"] == "DARK"]
     doses = sorted(set(bias["DOSE"]) & set(dark["DOSE"]))

--- a/tests/test_dose_analysis.py
+++ b/tests/test_dose_analysis.py
@@ -201,6 +201,7 @@ def test_compare_stage_differences_generates_heatmaps(tmp_path):
 
 
 def test_dynamic_range_analysis_outputs(tmp_path):
+    # Use the radiating stage which should be accepted alongside 'during'
     summary = pd.DataFrame([
         {"STAGE": "radiating", "CALTYPE": "BIAS", "DOSE": 1.0, "EXPTIME": 0.0, "MEAN": 10.0, "STD": 1.0},
         {"STAGE": "radiating", "CALTYPE": "DARK", "DOSE": 1.0, "EXPTIME": 1.0, "MEAN": 5.0, "STD": 2.0},


### PR DESCRIPTION
## Summary
- handle both `radiating` and `during` stages in dynamic range analysis
- note chosen stage in test

## Testing
- `pytest tests/test_dose_analysis.py::test_dynamic_range_analysis_outputs -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0fe7d4608331bc904fe4f2d4475f