### PR TITLE
Bias corrected dark statistics

### DIFF
--- a/tests/test_entrypoints_bias_dark.py
+++ b/tests/test_entrypoints_bias_dark.py
@@ -88,3 +88,6 @@ def test_entrypoints_remove_bias(tmp_path):
     rad_main(str(index_csv), str(rad_log), str(out_rad), ["pre"])
     mdark = fits.getdata(out_rad / "pre" / "master_dark_T10.0.fits")
     assert np.allclose(mdark, np.full((2, 2), 5.0))
+
+    stats = np.genfromtxt(out_rad / "pre" / "stats_dark.csv", delimiter=",", names=True)
+    assert np.allclose(stats["MEAN"], [5.0, 5.0])


### PR DESCRIPTION
## Summary
- compute master frames with new helper that marks bias subtraction
- ensure analyse_stage uses dataframe temperatures
- record bias subtraction in master dark FITS headers
- check dark statistics after bias correction

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffda3d54883318b5d6be4ec35695d