### PR TITLE
Add mean/std time plots for radiation analysis

### DIFF
--- a/tests/test_radiation_analysis.py
+++ b/tests/test_radiation_analysis.py
@@ -1,5 +1,6 @@
 import numpy as np
-from radiation_analysis import diff_heatmap
+import pandas as pd
+from radiation_analysis import diff_heatmap, plot_mean_std_vs_time
 
 
 def test_diff_heatmap_saves_npz(tmp_path):
@@ -8,3 +9,19 @@ def test_diff_heatmap_saves_npz(tmp_path):
     out_png = tmp_path / "diff.png"
     diff_heatmap(ref, targ, str(out_png), "title")
     assert (tmp_path / "diff.npz").is_file()
+
+
+def test_plot_mean_std_vs_time_creates_png(tmp_path):
+    df = pd.DataFrame(
+        {
+            "TEMP": [10.0, 10.0, 20.0, 20.0],
+            "FRAME": [0, 1, 0, 1],
+            "MEAN": [1.0, 1.1, 2.0, 2.2],
+            "STD": [0.1, 0.1, 0.2, 0.2],
+        }
+    )
+    csv = tmp_path / "stats.csv"
+    df.to_csv(csv, index=False)
+    out_png = tmp_path / "plot.png"
+    plot_mean_std_vs_time(str(csv), str(out_png))
+    assert out_png.is_file()


### PR DESCRIPTION
## Summary
- plot mean and std over time grouped by temperature
- plot bias and dark metrics when analysing each stage
- test PNG creation of the new plotting helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68500ddb5e508331b027430ace59023e