### PR TITLE
Enhance radiation pipeline options and plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,15 @@ python run_full_radiation_pipeline.py \
     path/to/irrad_dataset \
     path/to/radiationLogCompleto.csv \
     output_dir/
+
+Use ``--ignore-temp`` to combine all frames regardless of temperature when
+building masters.
 ```
 
 The output directory will contain subfolders `pre/`, `radiating/` and `post/`
 with all intermediate results, plots and radiation model fits.  Additional
 precision metrics are stored under `output_dir/precision/`.
+
+The script also recognises datasets arranged as ``<dose>kRads/`` directories with
+``fits/`` and an optional ``radiationLogDef.csv`` inside each one. When the log
+is missing the dose is distributed linearly between successive directories.

--- a/operation_analysis.py
+++ b/operation_analysis.py
@@ -251,25 +251,9 @@ def _plot_intensity_stats(
     m = np.array(means, dtype=float)
     s = np.array(stds, dtype=float)
 
-    if len(t) > 1:
-        try:
-            mean_fit = np.polyfit(t, m, 1)
-        except np.linalg.LinAlgError:
-            mean_fit = (0.0, float(np.mean(m)))
-        try:
-            std_fit = np.polyfit(t, s, 1)
-        except np.linalg.LinAlgError:
-            std_fit = (0.0, float(np.mean(s)))
-    else:
-        mean_fit = (0.0, float(np.mean(m)))
-        std_fit = (0.0, float(np.mean(s)))
-    trend_t = np.array([t[0], t[-1]])
-
     plt.figure(figsize=(8, 4))
     plt.plot(t, m, label="Mean")
-    plt.plot(t, s, label="StdDev")
-    plt.plot(trend_t, mean_fit[0] * trend_t + mean_fit[1], "k--", label="Mean Trend")
-    plt.plot(trend_t, std_fit[0] * trend_t + std_fit[1], "r--", label="Std Trend")
+    plt.fill_between(t, m - s, m + s, alpha=0.3, label="StdDev")
     plt.xlabel("Time")
     plt.ylabel("Value")
     plt.legend()


### PR DESCRIPTION
## Summary
- support datasets organised as `<dose>kRads/` folders
- allow ignoring temperature grouping via `--ignore-temp`
- improve intensity plots with shaded standard deviation and per-exposure dark plots
- expose `--ignore-temp` on radiation analysis CLI and main pipeline
- document new CLI option and folder layout in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850153efd688331bdcfd2f528d1200c