### PR TITLE
Improve verbose support in full radiation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ precision.
 python run_full_radiation_pipeline.py \
     path/to/irrad_dataset \
     path/to/radiationLogCompleto.csv \
-    output_dir/
+    output_dir/ [--verbose]
 
 Use ``--ignore-temp`` to combine all frames regardless of temperature when
 building masters.
@@ -284,5 +284,7 @@ with all intermediate results, plots and radiation model fits.  Additional
 precision metrics are stored under `output_dir/precision/`.
 
 The script also recognises datasets arranged as ``<dose>kRads/`` directories with
-``fits/`` and an optional ``radiationLogDef.csv`` inside each one. When the log
-is missing the dose is distributed linearly between successive directories.
+``fits/`` and an optional ``radiationLogDef.csv`` inside each one. In this layout
+the pipeline reads the already converted FITS from the ``fits/`` subfolder
+instead of the raw frames. When the log is missing the dose is distributed
+linearly between successive directories.

--- a/run_full_radiation_pipeline.py
+++ b/run_full_radiation_pipeline.py
@@ -287,7 +287,24 @@ def run_pipeline(
     output_dir: str,
     *,
     ignore_temp: bool = False,
+    verbose: bool = False,
 ) -> None:
+    """Run the complete irradiation workflow.
+
+    Parameters
+    ----------
+    dataset_root : str
+        Path to the dataset root.
+    radiation_log : str
+        Location of ``radiationLogCompleto.csv``.
+    output_dir : str
+        Directory where results are stored.
+    ignore_temp : bool, optional
+        Combine frames ignoring their temperature groups.
+    verbose : bool, optional
+        Forward the verbose flag to submodules for detailed logs.
+    """
+
     logger.info("Starting radiation pipeline")
     _ensure_conversion(dataset_root)
     index_csv = os.path.join(dataset_root, "index.csv")
@@ -312,7 +329,7 @@ def run_pipeline(
     precision_dir = os.path.join(output_dir, "precision")
     os.makedirs(precision_dir, exist_ok=True)
     logger.info("Computing precision metrics")
-    dose_analysis.main(index_csv, precision_dir)
+    dose_analysis.main(index_csv, precision_dir, verbose)
 
 
 def main() -> None:
@@ -336,6 +353,7 @@ def main() -> None:
         args.radiation_log,
         args.output_dir,
         ignore_temp=args.ignore_temp,
+        verbose=args.verbose,
     )
 
 


### PR DESCRIPTION
## Summary
- propagate `--verbose` to dose analysis
- document verbose mode and FITS-only kRads layout

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68502937d8988331aa1cccf5c864539d