### PR TITLE
Add progress bars and scoped debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ python run_full_radiation_pipeline.py \
 
 Use ``--ignore-temp`` to combine all frames regardless of temperature when
 building masters.
+Running with ``--verbose`` enables debug logs and displays progress bars for
+longer operations.
 ```
 
 The output directory will contain subfolders `pre/`, `radiating/` and `post/`

--- a/fit_radiation_model.py
+++ b/fit_radiation_model.py
@@ -29,6 +29,7 @@ import json
 import os
 import logging
 from typing import Tuple
+from tqdm import tqdm
 
 import numpy as np
 import pandas as pd
@@ -69,10 +70,12 @@ def _load_npz(path: str) -> dict:
     }
 
 
-def load_frames(directory: str) -> pd.DataFrame:
+def load_frames(directory: str, *, verbose: bool = False) -> pd.DataFrame:
     """Return per-frame statistics from ``directory``."""
     rows = []
-    for name in sorted(os.listdir(directory)):
+    iterator = sorted(os.listdir(directory))
+    iterator = tqdm(iterator, desc="load", ncols=80, disable=not verbose)
+    for name in iterator:
         path = os.path.join(directory, name)
         if not os.path.isfile(path):
             continue


### PR DESCRIPTION
## Summary
- display a load progress bar in `fit_radiation_model.load_frames`
- fit pipeline passes verbosity flag into `load_frames`
- only set DEBUG for project loggers when `--verbose` is used
- document verbose behaviour in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850328fd6088331ab5200871fe786ef