### PR TITLE
Add radiation dose table support

### DIFF
--- a/run_full_analysis_radiation.py
+++ b/run_full_analysis_radiation.py
@@ -25,6 +25,7 @@ import matplotlib.pyplot as plt
 
 import radiation_analysis
 import dose_analysis
+import utils
 from run_full_radiation_pipeline import _ensure_conversion
 
 
@@ -138,7 +139,8 @@ def run_pipeline(dataset_root: str, output_dir: str, *, ignore_temp: bool = Fals
     radiation_analysis.main(index_csv, rad_csv, stage_dir, stages=["radiating"], ignore_temp=ignore_temp)
 
     dose_dir = os.path.join(output_dir, "dose_analysis")
-    dose_analysis.main(index_csv, dose_dir, verbose)
+    dose_map = utils.read_radiation_log(rad_csv)
+    dose_analysis.main(index_csv, dose_dir, verbose, dose_table=dose_map)
 
     summary_csv = os.path.join(dose_dir, "dose_summary.csv")
     if os.path.isfile(summary_csv):

--- a/run_full_radiation_pipeline.py
+++ b/run_full_radiation_pipeline.py
@@ -33,6 +33,7 @@ import fit_radiation_model
 from operation_analysis import _plot_intensity_stats, _parse_rads
 import dose_analysis
 from utils import index_dataset
+import utils
 from tqdm import tqdm
 from bias_pipeline.bias_pipeline.steps.step4_generate_synthetic_bias import (
     generate_synthetic_bias,
@@ -364,7 +365,8 @@ def run_pipeline(
     precision_dir = os.path.join(output_dir, "precision")
     os.makedirs(precision_dir, exist_ok=True)
     logger.info("Computing precision metrics")
-    dose_analysis.main(index_csv, precision_dir, verbose)
+    dose_map = utils.read_radiation_log(radiation_log)
+    dose_analysis.main(index_csv, precision_dir, verbose, dose_table=dose_map)
 
 
 def main() -> None:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,42 @@
+import os
+import logging
+from typing import Dict
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def read_radiation_log(path: str) -> Dict[int, float]:
+    """Return mapping from ``FrameNum`` to radiation dose.
+
+    Parameters
+    ----------
+    path : str
+        CSV file produced by the irradiation setup.
+
+    Returns
+    -------
+    dict[int, float]
+        Mapping of frame number to dose. Empty if the file cannot be read.
+    """
+    if not os.path.isfile(path):
+        logger.warning("Radiation log %s not found", path)
+        return {}
+    try:
+        df = pd.read_csv(path)
+    except Exception as exc:
+        logger.warning("Failed to read radiation log %s: %s", path, exc)
+        return {}
+
+    frame = pd.to_numeric(df.get("FrameNum"), errors="coerce")
+    if frame.isna().all():
+        frame = pd.Series(range(len(df)))
+
+    dose_col = "Dose" if "Dose" in df.columns else "RadiationLevel"
+    dose = pd.to_numeric(df.get(dose_col), errors="coerce")
+
+    mapping: Dict[int, float] = {}
+    for fr, d in zip(frame, dose):
+        if pd.notna(fr) and pd.notna(d):
+            mapping[int(fr)] = float(d)
+    return mapping


### PR DESCRIPTION
## Summary
- enable loading radiation dose from log files via new `utils.read_radiation_log`
- allow `_group_paths` and `_estimate_dose_rate` to use dose tables
- update analysis scripts to provide dose mapping
- test extraction of dose and dose-rate from log tables

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503ecd7c488331b2b63bf668518768