### PR TITLE
Switch temperature header logs to debug

### DIFF
--- a/dose_analysis.py
+++ b/dose_analysis.py
@@ -82,11 +82,11 @@ def _temperature_from_header(path: str) -> float | None:
         if "TEMP" in hdr:
             return float(hdr["TEMP"])
     except Exception as exc:
-        if logger.isEnabledFor(logging.INFO):
-            logger.info("Error reading TEMP from %s: %s", path, exc)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Error reading TEMP from %s: %s", path, exc)
         return None
-    if logger.isEnabledFor(logging.INFO):
-        logger.info("Temperature missing for %s", path)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Temperature missing for %s", path)
     return None
 
 


### PR DESCRIPTION
## Summary
- reduce logging noise when reading TEMP headers by using debug level messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685041bd496c8331b2b5bd1c35bf77cf