### PR TITLE
Add wrapper script for analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,19 @@ The script also recognises datasets arranged as ``<dose>kRads/`` directories wit
 the pipeline reads the already converted FITS from the ``fits/`` subfolder
 instead of the raw frames. When the log is missing the dose is distributed
 linearly between successive directories.
+
+## Full dose analysis
+
+`run_full_analysis_pipeline.py` provides a thin wrapper around
+`run_full_analysis_radiation.run_pipeline`. It processes irradiated
+folders arranged as `<dose>kRads/` with a `fits/` subdirectory and
+produces the same outputs as the radiation pipeline.
+
+```bash
+python run_full_analysis_pipeline.py \
+    path/to/dose_dirs \
+    output_dir/ [--verbose]
+```
+
+Use ``--ignore-temp`` to group all frames regardless of temperature.
+

--- a/run_full_analysis_pipeline.py
+++ b/run_full_analysis_pipeline.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper for :mod:`run_full_analysis_radiation`.
+
+This script simply forwards its command line arguments to
+:func:`run_full_analysis_radiation.run_pipeline` so that existing
+documentation referencing ``run_full_analysis_pipeline.py`` keeps
+working.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from run_full_analysis_radiation import run_pipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run full analysis on irradiation FITS directories"
+    )
+    parser.add_argument("dataset_root", help="Directory containing <dose>kRads folders")
+    parser.add_argument("output_dir", help="Directory for results")
+    parser.add_argument(
+        "--ignore-temp",
+        action="store_true",
+        help="Do not group frames by temperature",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    run_pipeline(
+        args.dataset_root,
+        args.output_dir,
+        ignore_temp=args.ignore_temp,
+        verbose=args.verbose,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `run_full_analysis_pipeline.py` wrapper that calls `run_full_analysis_radiation.run_pipeline`
- document how to use the wrapper in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685041be793883318418f1db8fd72e73