### PR TITLE
Add dose-based grouping option

### DIFF
--- a/run_full_analysis_radiation.py
+++ b/run_full_analysis_radiation.py
@@ -120,7 +120,14 @@ def _plot_dark_mean(df: pd.DataFrame, out_dir: str) -> None:
         plt.close()
 
 
-def run_pipeline(dataset_root: str, output_dir: str, *, ignore_temp: bool = False, verbose: bool = False) -> None:
+def run_pipeline(
+    dataset_root: str,
+    output_dir: str,
+    *,
+    ignore_temp: bool = False,
+    verbose: bool = False,
+    group_by_dose: bool = False,
+) -> None:
     """Run the full irradiation analysis workflow."""
 
     logger.info("Preparing dataset under %s", dataset_root)
@@ -136,7 +143,14 @@ def run_pipeline(dataset_root: str, output_dir: str, *, ignore_temp: bool = Fals
     rad_csv = os.path.join(dataset_root, "radiationLogCompleto.csv")
 
     stage_dir = os.path.join(output_dir, "radiation_analysis")
-    radiation_analysis.main(index_csv, rad_csv, stage_dir, stages=["radiating"], ignore_temp=ignore_temp)
+    radiation_analysis.main(
+        index_csv,
+        rad_csv,
+        stage_dir,
+        stages=["radiating"],
+        ignore_temp=ignore_temp,
+        group_by_dose=group_by_dose,
+    )
 
     dose_dir = os.path.join(output_dir, "dose_analysis")
     dose_map = utils.read_radiation_log(rad_csv)
@@ -156,12 +170,23 @@ def main() -> None:
     parser.add_argument("dataset_root", help="Directory containing <dose>kRads folders")
     parser.add_argument("output_dir", help="Directory for results")
     parser.add_argument("--ignore-temp", action="store_true", help="Do not group frames by temperature")
+    parser.add_argument(
+        "--group-by-dose",
+        action="store_true",
+        help="Group all frames for a dose when radiation is constant",
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO, format="%(levelname)s: %(message)s")
 
-    run_pipeline(args.dataset_root, args.output_dir, ignore_temp=args.ignore_temp, verbose=args.verbose)
+    run_pipeline(
+        args.dataset_root,
+        args.output_dir,
+        ignore_temp=args.ignore_temp,
+        verbose=args.verbose,
+        group_by_dose=args.group_by_dose,
+    )
 
 
 if __name__ == "__main__":

--- a/run_full_radiation_pipeline.py
+++ b/run_full_radiation_pipeline.py
@@ -330,6 +330,7 @@ def run_pipeline(
     *,
     ignore_temp: bool = False,
     verbose: bool = False,
+    group_by_dose: bool = False,
 ) -> None:
     """Run the complete irradiation workflow.
 
@@ -356,6 +357,7 @@ def run_pipeline(
         output_dir,
         _STAGES,
         ignore_temp=ignore_temp,
+        group_by_dose=group_by_dose,
     )
 
     for stage in _STAGES:
@@ -385,6 +387,11 @@ def main() -> None:
         action="store_true",
         help="Do not group frames by temperature",
     )
+    parser.add_argument(
+        "--group-by-dose",
+        action="store_true",
+        help="Group all frames for a dose when radiation is constant",
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -403,6 +410,7 @@ def main() -> None:
         args.output_dir,
         ignore_temp=args.ignore_temp,
         verbose=args.verbose,
+        group_by_dose=args.group_by_dose,
     )
 
 

--- a/tests/test_radiation_analysis.py
+++ b/tests/test_radiation_analysis.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
-from radiation_analysis import diff_heatmap, plot_mean_std_vs_time
+from astropy.io import fits
+from radiation_analysis import diff_heatmap, plot_mean_std_vs_time, main as rad_main
 
 
 def test_diff_heatmap_saves_npz(tmp_path):
@@ -25,3 +26,43 @@ def test_plot_mean_std_vs_time_creates_png(tmp_path):
     out_png = tmp_path / "plot.png"
     plot_mean_std_vs_time(str(csv), str(out_png))
     assert out_png.is_file()
+
+
+def _make_fits(path, value, temp=10.0, exp=1.0, frame=0):
+    hdu = fits.PrimaryHDU(np.full((2, 2), value, dtype=np.float32))
+    hdu.header["TEMP"] = temp
+    hdu.header["EXPTIME"] = exp
+    hdu.header["FRAMENUM"] = frame
+    hdu.writeto(path, overwrite=True)
+
+
+def test_group_by_dose_constant_dataset(tmp_path):
+    d1 = tmp_path / "d1.fits"
+    d2 = tmp_path / "d2.fits"
+    _make_fits(d1, 1, temp=10.0, exp=1.0, frame=0)
+    _make_fits(d2, 2, temp=20.0, exp=1.0, frame=1)
+
+    index_csv = tmp_path / "index.csv"
+    pd.DataFrame(
+        {
+            "PATH": [str(d1), str(d2)],
+            "CALTYPE": ["DARK", "DARK"],
+            "STAGE": ["pre", "pre"],
+            "VACUUM": ["air", "air"],
+            "TEMP": [10.0, 20.0],
+            "ZEROFRACTION": [0.0, 0.0],
+            "BADFITS": [False, False],
+        }
+    ).to_csv(index_csv, index=False)
+
+    rad_csv = tmp_path / "rad.csv"
+    pd.DataFrame({"FrameNum": [0, 1], "RadiationLevel": [0, 0]}).to_csv(rad_csv, index=False)
+
+    out_dir = tmp_path / "out"
+    rad_main(str(index_csv), str(rad_csv), str(out_dir), ["pre"], group_by_dose=True)
+
+    master = out_dir / "pre" / "master_dark_T0.0.fits"
+    assert master.is_file()
+    # no temperature-separated masters should exist
+    assert not (out_dir / "pre" / "master_dark_T10.0.fits").exists()
+    assert not (out_dir / "pre" / "master_dark_T20.0.fits").exists()


### PR DESCRIPTION
## Summary
- allow grouping by dose in master generation and stage analysis
- expose `--group-by-dose` flag in radiation pipeline scripts
- test constant-dose dataset processing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685041b36dac8331adc6ed4b5aba2ba8